### PR TITLE
Updated Hue API endpoint

### DIFF
--- a/logic/utils.py
+++ b/logic/utils.py
@@ -18,7 +18,7 @@ def search_for_bridge(timeout=3):
     finds one."""
     from packages import requests
 
-    r = requests.get('http://www.meethue.com/api/nupnp', timeout=timeout)
+    r = requests.get('https://discovery.meethue.com', timeout=timeout)
     bridges = r.json()
 
     if len(bridges) > 0:


### PR DESCRIPTION
The Hue discovery API endpoint has changed from `http://www.meethue.com/api/nupnp` to `https://discovery.meethue.com`. This breaks the initial setup of the workflow.

Source: https://developers.meethue.com/news/