### PR TITLE
Recalling scenes for deconz bridge

### DIFF
--- a/logic/action.py
+++ b/logic/action.py
@@ -168,7 +168,23 @@ class HueAction:
             endpoint = '/schedules'
 
         elif function == 'set':
-            data = {'scene': value}
+            # if bridge is deconz, scenes are set differently.
+            # what we need is groups:group_id:scenes:scene_id:recall
+            is_deconz = False
+            try:
+                if workflow.stored_data("full_state")["config"]["modelid"] == "deCONZ":
+                    is_deconz = True
+            except:
+                # not sure if hue also returns config/modelid
+                pass
+
+            if is_deconz:
+                method = 'put'
+                endpoint = '/groups/{}/scenes/{}/recall'.format(rid, value)
+                data = {}
+            else:
+                data = {'scene': value}
+
 
         elif function == 'save':
             lids = utils.get_group_lids(rid)

--- a/logic/filters.py
+++ b/logic/filters.py
@@ -254,6 +254,8 @@ save_scene:
                         valid=True)
 
                 if type == self.GROUP_TYPE:
+                    # maybe settings scenes should be disabled for "All lights"
+                    # if the bridge is deconz
                     self._add_item(
                         'set_scene',
                         autocomplete='groups:%s:set:' % id)

--- a/logic/utils.py
+++ b/logic/utils.py
@@ -143,6 +143,9 @@ def get_scenes(group_id):
 
     if is_deconz:
         workflow.logger.debug("This is deconz")
+        # Not sure if "All lights" always has id 0
+        if group_id == "0":
+            return {}
         scenes = data["groups"][group_id]["scenes"]
         workflow.logger.debug(scenes)
         # in deconz, scenes are stored a list, convert to dict

--- a/logic/utils.py
+++ b/logic/utils.py
@@ -129,13 +129,34 @@ def get_group_lids(group_id):
 
 
 def get_scenes(group_id):
-    data = workflow.stored_data('full_state')
-    scenes = data['scenes']
-    lids = get_group_lids(group_id)
-    return {id: scene for id, scene in scenes.iteritems() if (
-            set(scene['lights']) == set(lids) and
-            scene['name'] != 'Off') and
-            scene['version'] >= 2}
+    data = workflow.stored_data("full_state")
+
+    # check if this is deconz, scenes are stored per group
+    # can this be done elsewhere?
+    is_deconz = False
+    try:
+        if data["config"]["modelid"] == "deCONZ":
+            is_deconz = True
+    except:
+        # not sure if hue also returns config/modelid
+        pass
+
+    if is_deconz:
+        workflow.logger.debug("This is deconz")
+        scenes = data["groups"][group_id]["scenes"]
+        workflow.logger.debug(scenes)
+        # in deconz, scenes are stored a list, convert to dict
+        return {scene["id"]: scene for scene in scenes}
+    else:
+        # it's probably a hue
+        scenes = data["scenes"]
+        lids = get_group_lids(group_id)
+        return {
+            id: scene
+            for id, scene in scenes.iteritems()
+            if (set(scene["lights"]) == set(lids) and scene["name"] != "Off")
+            and scene["version"] >= 2
+        }
 
 
 def get_color_value(color):


### PR DESCRIPTION
This adds rudimentary support for recalling scenes, if the bridge is a deconz #52 . 

I am not happy that the stored workflow data has to be recalled everytime one needs to check if the bridge is deconz or not. Maybe there is a cleaner solution to set the property once.

