### PR TITLE
Handle multiple queries at once

### DIFF
--- a/logic/action.py
+++ b/logic/action.py
@@ -184,20 +184,22 @@ class HueAction:
 
         return
 
-
 def main(workflow):
-    query = workflow.args[0].split(':')
-
-    if query[0] == 'set_bridge':
-        bridge_ip = workflow.args[0].split(':', 1)[1]
-        setup.set_bridge(bridge_ip)
-    else:
-        action = HueAction()
-        try:
-            action.execute(query)
-            print(('Action completed! <%s>' % workflow.args[0]).encode('utf-8'))
-        except ValueError:
-            pass
+    # Handle multiple queries separated with '|' (pipe) character
+    queries = workflow.args[0].split('|')
+    
+    for this_query in queries:
+        query = this_query.split(':')
+        if this_query == 'set_bridge':
+            bridge_ip = this_query.split(':', 1)[1]
+            setup.set_bridge(bridge_ip)
+        else:
+            action = HueAction()
+            try:
+                action.execute(query)
+                print(('Action completed! <%s>' % this_query).encode('utf-8'))
+            except ValueError:
+                pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The documentation says that this action can handle multiple queries passed into it when separated with a `|`, but it looks like that wasn't actually implemented anywhere. This enables that behavior, and (should) resolve #51.