### PR TITLE
Update /usr/bin/python to /usr/local/bin/python

### DIFF
--- a/logic/packages/workflow/background.py
+++ b/logic/packages/workflow/background.py
@@ -230,7 +230,7 @@ def run_in_background(name, args, **kwargs):
         _log().debug('[%s] command cached: %s', name, argcache)
 
     # Call this script
-    cmd = ['/usr/bin/python', __file__, name]
+    cmd = ['/usr/local/bin/python', __file__, name]
     _log().debug('[%s] passing job to background runner: %r', name, cmd)
     retcode = subprocess.call(cmd)
 

--- a/logic/packages/workflow/workflow.py
+++ b/logic/packages/workflow/workflow.py
@@ -2330,7 +2330,7 @@ class Workflow(object):
             update_script = os.path.join(os.path.dirname(__file__),
                                          b'update.py')
 
-            cmd = ['/usr/bin/python', update_script, 'check', repo, version]
+            cmd = ['/usr/local/bin/python', update_script, 'check', repo, version]
 
             if self.prereleases:
                 cmd.append('--prereleases')
@@ -2369,7 +2369,7 @@ class Workflow(object):
         update_script = os.path.join(os.path.dirname(__file__),
                                      b'update.py')
 
-        cmd = ['/usr/bin/python', update_script, 'install', repo, version]
+        cmd = ['/usr/local/bin/python', update_script, 'install', repo, version]
 
         if self.prereleases:
             cmd.append('--prereleases')


### PR DESCRIPTION
This should help folks who had to do 

```
pyenv install 2.7.18
ln -s "${HOME}/.pyenv/versions/2.7.18/bin/python2.7" "/usr/local/bin/python"
```

to get python2 back on their machine. The plist file needs to be updated to point to /usr/local/bin/python as well.